### PR TITLE
(maint): fix typo

### DIFF
--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -238,7 +238,7 @@ return packer.startup(function()
       after = "nvim-cmp",
    }
 
-   -- fuzzy searching for everythign
+   -- fuzzy searching for everything
    use {
       "nvim-telescope/telescope.nvim",
       cmd = "Telescope",


### PR DESCRIPTION
`everthign` -> `everything`

Signed off by: Vladislav Doster <vlad_doster@hms.harvard.edu>