### PR TITLE
[cmp]: A functional tab-completion selection

### DIFF
--- a/fnl/pack/cmp.fnl
+++ b/fnl/pack/cmp.fnl
@@ -4,6 +4,8 @@
 (local {: setup
         : mapping
         : visible
+        : select_prev_item
+        : select_next_item
         : complete
         :config {: compare : disable}
         :ItemField {:Kind kind :Abbr abbr :Menu menu}
@@ -11,10 +13,10 @@
 
 (local types (require :cmp.types))
 (local under-compare (require :cmp-under-comparator))
-(local {: lsp_expand 
-        : expand_or_jump 
-        : expand_or_jumpable 
-        : jump 
+(local {: lsp_expand
+        : expand_or_jump
+        : expand_or_jumpable
+        : jump
         : jumpable} (require :luasnip))
 
 ;; default icons (lspkind)
@@ -69,7 +71,7 @@
                   :<C-p> (mapping (mapping.select_prev_item {:behavior insert-behavior}) [:i :s])
                   :<Tab> (mapping (fn [fallback]
                                     (if (visible)
-                                        (mapping.select_next_item {:behavior insert-behavior})
+                                        (select_next_item {:behavior insert-behavior})
                                         (expand_or_jumpable)
                                         (expand_or_jump)
                                         (has-words-before)
@@ -79,7 +81,7 @@
                                   [:i :s :c])
                   :<S-Tab> (mapping (fn [fallback]
                                       (if (visible)
-                                          (mapping.select_prev_item {:behavior insert-behavior})
+                                          (select_prev_item {:behavior insert-behavior})
                                           (jumpable -1)
                                           (jump -1)
                                           (fallback)))


### PR DESCRIPTION
There is an issue with the current `cmp.fnl` config that prevents the user from selecting the completions through the usage of either <kbd>Tab</kbd>  or <kbd>S-Tab</kbd> keys.

After this PR's merger, the Nyoom user should be able to use the <kbd>Tab</kbd> key to select the next available completion and <kbd>S-Tab</kbd> to select the previous available completion!

Solves: #48 