### PR TITLE
Docs: typo in issue url

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -121,7 +121,7 @@ If you have an issue with a plugin in Nyoom.nvim, first you should report it her
 
 + I love pull requests and bug reports!
 + Don't hesitate to [tell me my lisp-fu
-  sucks](https://github.com/shaunsingh/nyoon.nvim/issues/new), but please tell me
+  sucks](https://github.com/shaunsingh/nyoom.nvim/issues/new), but please tell me
   why.
 + Don't see support for your language, or think it should be improved? Feel free to open an issue or PR with your changes
 


### PR DESCRIPTION
url leads to 404