### PR TITLE
make bash more discover able

### DIFF
--- a/bin/nyoom
+++ b/bin/nyoom
@@ -20,9 +20,9 @@ case "${1:-}" in
     mkdir -p lua
     if [ "$(uname)" == "Darwin" ]; then
         mv target/release/liboxocarbon.dylib lua/oxocarbon.so
-    elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
         mv target/release/liboxocarbon.so lua/oxocarbon.so
-    elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then
+    elif [ "$(expr substr "$(uname -s)" 1 10)" == "MINGW64_NT" ]; then
         mv target/release/oxocarbon.dll lua/oxocarbon.dll
     fi
     cd ~/.config/nvim
@@ -36,7 +36,7 @@ case "${1:-}" in
     ;;
   *)
     exec nvim --headless -S "$1" -i NONE -n -c 'echo""|qall!' -- "${@:2}"
-esac
+;; esac
 
 
 

--- a/bin/nyoom
+++ b/bin/nyoom
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o pipefail -o nounset
 
 case "${1:-}" in

--- a/bin/nyoom
+++ b/bin/nyoom
@@ -7,7 +7,7 @@ case "${1:-}" in
       "usage: $(basename "$0") [options] [script [args]]" \
       "Available options are:" \
       "install  install required plugins" \
-      "sync  sync nyoom modules and plugins" \
+      "sync  sync nyoom modules and plugins"
     ;;
   install)
     echo "Installing Required Plugins"
@@ -16,14 +16,14 @@ case "${1:-}" in
     echo "Building Colorscheme"
     git clone -q --depth 1 https://github.com/shaunsingh/oxocarbon.nvim.git ~/.local/share/nvim/site/pack/packer/start/oxocarbon.nvim
     cd ~/.local/share/nvim/site/pack/packer/start/oxocarbon.nvim
-    cargo build --release 
+    cargo build --release
     mkdir -p lua
     if [ "$(uname)" == "Darwin" ]; then
-        mv target/release/liboxocarbon.dylib lua/oxocarbon.so
+      mv target/release/liboxocarbon.dylib lua/oxocarbon.so
     elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
-        mv target/release/liboxocarbon.so lua/oxocarbon.so
+      mv target/release/liboxocarbon.so lua/oxocarbon.so
     elif [ "$(expr substr "$(uname -s)" 1 10)" == "MINGW64_NT" ]; then
-        mv target/release/oxocarbon.dll lua/oxocarbon.dll
+      mv target/release/oxocarbon.dll lua/oxocarbon.dll
     fi
     cd ~/.config/nvim
     ;;
@@ -36,9 +36,5 @@ case "${1:-}" in
     ;;
   *)
     exec nvim --headless -S "$1" -i NONE -n -c 'echo""|qall!' -- "${@:2}"
-;; esac
-
-
-
-
-
+    ;;
+esac


### PR DESCRIPTION
```
->> bin/nyoom install
exec: Failed to execute process '/home/luxus/.config/nvim/bin/nyoom': The file specified the interpreter '/bin/bash', which is not an executable command.

```
find bash in nixos and other more exotic situations