### PR TITLE
fix(cmp completion bug with deactivated rust module)

### DIFF
--- a/fnl/modules/completion/cmp/config.fnl
+++ b/fnl/modules/completion/cmp/config.fnl
@@ -4,6 +4,19 @@
 
 (set! completeopt [:menu :menuone :noselect])
 
+;; set the cmp sources, but keep it conditioned on the modules
+ (local src [])
+ (nyoom-module-p! lsp (table.insert src {:name :nvim_lsp}))
+
+ (nyoom-module-p! rust (table.insert src {:name :crates}))
+
+ (nyoom-module-p! eval (table.insert src {:name :conjure}))
+
+ ;; add general cmp sources
+ (table.insert src {:name :luasnip})
+ (table.insert src {:name :buffer})
+ (table.insert src {:name :path})
+
 ;; default icons (lspkind)
 (local icons {:Text ""
               :Method ""
@@ -54,15 +67,7 @@
                                       (fallback)))
                                   [:i :s])
                       "<space>" (cmp.mapping.confirm {:select false})}
-            :sources [(nyoom-module-p! lsp
-                        {:name :nvim_lsp})
-                      {:name :luasnip}
-                      (nyoom-module-p! eval
-                        {:name :conjure})
-                      (nyoom-module-p! rust
-                        {:name :crates})
-                      {:name :buffer}
-                      {:name :path}]
+            :sources src
             :formatting {:fields {1 :kind 2 :abbr 3 :menu}
                          :format (fn [_ vim-item]
                                    (set vim-item.menu vim-item.kind)


### PR DESCRIPTION
This PR should fix the problem mentioned in #66. 
With the deactivated rust module the `nyoom-module-p!` macro resulted in a `nil` value for the `crates` source.
`cmp` did not like that.

This was the problematic piece:
https://github.com/shaunsingh/nyoom.nvim/blob/4ce896218dca6624d507bba3d37609877276b168/fnl/modules/completion/cmp/config.fnl#L62-L63

I'm sure there is a much more elegant way to 'fennelize' the code, but at least it should work or give somebody else an idea where to look.
I was not able to reproduce the error anymore with this fix.

If you would like some changes, please let me know.