### PR TITLE
fix error calling script from another directory

### DIFF
--- a/bin/nyoom
+++ b/bin/nyoom
@@ -9,6 +9,9 @@ setup_envs() {
 
 setup_envs
 
+# Change directory to config directory
+pushd ${CONFIG_PATH}
+
 case "${1:-}" in
   "")
     printf "%s\n%s\n  %s\n%s\n" \
@@ -68,3 +71,5 @@ case "${1:-}" in
     fi
     ;;
 esac
+# Get out of ${CONFIG_PATH}
+popd


### PR DESCRIPTION
When using the script from a directory other than the config one(CONFIG_PATH), the script will error out with "module not found", as the "require" seems to use relative paths.

The changes i made make it so that no matter from where the script is called, the "PATH" will always be CONFIG_PATH. 