### PR TITLE
Rename prompt title of oldfiles as Recent files

### DIFF
--- a/fnl/modules/completion/telescope/config.fnl
+++ b/fnl/modules/completion/telescope/config.fnl
@@ -14,7 +14,8 @@
                                               :height 0.8
                                               :preview_cutoff 120}
                               :set_env {:COLORTERM :truecolor}
-                              :dynamic_preview_title true}})
+                              :dynamic_preview_title true}
+                    :pickers {:oldfiles {:prompt_title "Recent files"}}})
 
 ;; Load extensions
 


### PR DESCRIPTION
Just a cosmetic fix or two is what I am able to at the present.   Just wrapping my head around this fennel stuff...

Telescope 'oldfiles' is a double misnommer.  

1)  It is first of all gramatically incorrect for a title; looks more like a variable.  
2) It's actually the very opposite:  Its what you just worked on:   Recent files  (as indicated on the nyoom start page!)

This adds a default title for any 'oldfiles' Telescope picker as "Recent files"



