### PR TITLE
rename treesitter help parser to vimdoc

### DIFF
--- a/fnl/modules/tools/tree-sitter/config.fnl
+++ b/fnl/modules/tools/tree-sitter/config.fnl
@@ -8,7 +8,7 @@
                    (let [leap-ast (autoload :leap-ast)]
                      (map! [nxo] :gs `(leap-ast.leap) {:desc "Leap AST"}))))
 
-(local treesitter-filetypes [:help :fennel :vim :regex :query])
+(local treesitter-filetypes [:vimdoc :fennel :vim :regex :query])
 
 ;; conditionally install parsers
 


### PR DESCRIPTION
Treesitter help parser error.   (Should this type of thing need an issue opened before sending a pull request?)

From: https://neovim.io/doc/user/news-0.9.html

help treesitter parser was renamed to vimdoc. The only user-visible change is that language-specific highlight groups need to be renamed from @foo.help to @foo.vimdoc.

I suppose this will then cause an error for those on less than 9.   But I'm thinking that most people using nyoom will have the now current version of nvim.

